### PR TITLE
Added a secondary url for rclone if first is down + small improvements

### DIFF
--- a/QuestAppsDownloader.Services/Configurations/RcloneConfiguration.cs
+++ b/QuestAppsDownloader.Services/Configurations/RcloneConfiguration.cs
@@ -3,4 +3,5 @@
 public class RcloneConfiguration
 {
     public string DownloadUrl { get; set; }
+    public string AlternativeUrl { get; set; }
 }

--- a/QuestAppsDownloader/appsettings.json
+++ b/QuestAppsDownloader/appsettings.json
@@ -1,6 +1,7 @@
 {
   "RcloneConfiguration": {
-    "DownloadUrl": "https://downloads.rclone.org/rclone-current-windows-amd64.zip"
+    "DownloadUrl": "https://downloads.rclone.org/rclone-current-windows-amd64.zip",
+    "AlternativeUrl": "https://github.com/rclone/rclone/releases/download/v1.64.2/rclone-v1.64.2-windows-amd64.zip"
   },
   "VRPPublicConfiguration": {
     "Url": "https://wiki.vrpirates.club/downloads/vrp-public.json"

--- a/Tests/QuestAppsDownloader.Services.Tests/Services/RCloneServiceTests.cs
+++ b/Tests/QuestAppsDownloader.Services.Tests/Services/RCloneServiceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using NSubstitute.ReturnsExtensions;
 using QuestAppsDownloader.DTO.DTOs;
 using QuestAppsDownloader.Services.Configurations;
 using QuestAppsDownloader.Services.Exceptions;
@@ -17,9 +18,12 @@ public class RCloneServiceTests
 {
     private const string RcloneArchivePath = "./rclone.zip";
     private const string RcloneFolderPath = "./rclone";
+    private const string RcloneExecutable = "rclone.exe";
     private const string MetadataDirectoryPath = "./metadata";
     private const string MetadataArchive = "meta.7z";
     private const string DownloadsFolderPath = "./downloads";
+    private const string ReleaseName = "ReleaseName";
+    private const string ReleaseNameMD5 = "91c8b06bfb0bc63074f082d4b7408411";
 
     private static readonly IFixture Auto = new Fixture();
 
@@ -38,14 +42,28 @@ public class RCloneServiceTests
         _rcloneWrapper = Substitute.For<IRCloneWrapper>();
 
         _metadataConfiguration = new MetadataConfiguration { MetadataCloudPath = Auto.Create<string>() };
-        _rcloneConfiguration = new RcloneConfiguration { DownloadUrl = "http://google.com/" };
+        _rcloneConfiguration = new RcloneConfiguration { DownloadUrl = "http://google.com/", AlternativeUrl = "https://bing.com/" };
 
         _subject = new RCloneService(_httpWrapper, _fileManager, _rcloneWrapper, Options.Create(_metadataConfiguration), Options.Create(_rcloneConfiguration));
     }
 
     [Fact]
-    public async Task SetupRclone_ThenDownloadExtractAndDeleteArchive()
+    public async Task SetupRclone_WhenRcloneFound_ThenDoesNotDownloadArchive()
     {
+        _fileManager.GetFilePath(RcloneFolderPath, RcloneExecutable).Returns(Auto.Create<string>());
+
+        await _subject.SetupRclone();
+
+        await _httpWrapper.DidNotReceiveWithAnyArgs().DownloadFileAsync(default, default);
+        _fileManager.DidNotReceiveWithAnyArgs().UnzipArchive(default, default);
+        _fileManager.DidNotReceiveWithAnyArgs().DeleteFile(default);
+    }
+
+    [Fact]
+    public async Task SetupRclone_WhenRcloneNotFound_ThenDownloadExtractAndDeleteArchive()
+    {
+        _fileManager.GetFilePath(RcloneFolderPath, RcloneExecutable).ReturnsNull();
+
         await _subject.SetupRclone();
 
         await _httpWrapper.Received(1).DownloadFileAsync(_rcloneConfiguration.DownloadUrl, RcloneArchivePath);
@@ -54,10 +72,25 @@ public class RCloneServiceTests
     }
 
     [Fact]
-    public async Task SetupRclone_WhenDownloadFails_ThenThrowsRCloneSetupException()
+    public async Task SetupRclone_WhenRcloneNotFoundAndPrimaryDownloadFails_ThenDownloadsUsingAlternativeUrl()
+    {
+        _fileManager.GetFilePath(RcloneFolderPath, RcloneExecutable).ReturnsNull();
+        _httpWrapper.DownloadFileAsync(_rcloneConfiguration.DownloadUrl, RcloneArchivePath).Throws(new Exception());
+
+        await _subject.SetupRclone();
+
+        await _httpWrapper.Received(1).DownloadFileAsync(_rcloneConfiguration.AlternativeUrl, RcloneArchivePath);
+        _fileManager.Received(1).UnzipArchive(RcloneArchivePath, RcloneFolderPath);
+        _fileManager.Received(1).DeleteFile(RcloneArchivePath);
+    }
+
+    [Fact]
+    public async Task SetupRclone_WhenRcloneNotFoundAndPrimaryAndSecondaryDownloadFail_ThenThrowsRCloneSetupException()
     {
         var expectedException = new RCloneSetupException();
+        _fileManager.GetFilePath(RcloneFolderPath, RcloneExecutable).ReturnsNull();
         _httpWrapper.DownloadFileAsync(_rcloneConfiguration.DownloadUrl, RcloneArchivePath).Throws(new Exception());
+        _httpWrapper.DownloadFileAsync(_rcloneConfiguration.AlternativeUrl, RcloneArchivePath).Throws(new Exception());
 
         var act = () => _subject.SetupRclone();
 
@@ -93,30 +126,26 @@ public class RCloneServiceTests
     public async Task DownloadGame_ThenCopyAndExtractArchive()
     {
         var password = Auto.Create<byte[]>();
-        var releaseName = "ReleaseName";
-        var md5ReleaseName = "91c8b06bfb0bc63074f082d4b7408411";
-        var destinationDirectory = $"{DownloadsFolderPath}/{md5ReleaseName}";
+        var destinationDirectory = $"{DownloadsFolderPath}/{ReleaseNameMD5}";
         var vrpPublic = Auto.Build<VRPPublic>().With(v => v.Password, Convert.ToBase64String(password)).Create();
         var files = Auto.CreateMany<string>().ToList();
         _fileManager.GetFilesInDirectory(destinationDirectory, "*.7z*").Returns(files);
 
-        await _subject.DownloadGame(releaseName, vrpPublic);
+        await _subject.DownloadGame(ReleaseName, vrpPublic);
 
-        await _rcloneWrapper.Received(1).CopyAsync(vrpPublic.BaseUri, $":http:/{md5ReleaseName}/", destinationDirectory);
+        await _rcloneWrapper.Received(1).CopyAsync(vrpPublic.BaseUri, $":http:/{ReleaseNameMD5}/", destinationDirectory);
         _fileManager.Received(1).Unzip7zArchive(files.First(), destinationDirectory, vrpPublic.GetDecodedPassword());
     }
 
     [Fact]
     public async Task DownloadGame_WhenCopyFails_ThenThrowsRCloneCloudException()
     {
-        var releaseName = "ReleaseName";
-        var md5ReleaseName = "91c8b06bfb0bc63074f082d4b7408411";
-        var destinationDirectory = $"{DownloadsFolderPath}/{md5ReleaseName}";
+        var destinationDirectory = $"{DownloadsFolderPath}/{ReleaseNameMD5}";
         var vrpPublic = Auto.Create<VRPPublic>();
         var expectedException = new RCloneCloudException(vrpPublic.BaseUri);
-        _rcloneWrapper.CopyAsync(vrpPublic.BaseUri, $":http:/{md5ReleaseName}/", destinationDirectory).Throws(expectedException);
+        _rcloneWrapper.CopyAsync(vrpPublic.BaseUri, $":http:/{ReleaseNameMD5}/", destinationDirectory).Throws(expectedException);
 
-        var act = () => _subject.DownloadGame(releaseName, vrpPublic);
+        var act = () => _subject.DownloadGame(ReleaseName, vrpPublic);
 
         await act.Should().ThrowAsync<RCloneCloudException>(expectedException.Message);
     }


### PR DESCRIPTION
- If first rclone download url is down and download fails then tries the alternative github one.
- If rclone has already been downloaded previously then doesn't download it again (may improve app startup speed)
- Unit tests improvements to reflect changes