### PR TITLE
Fix handling archive extraction error

### DIFF
--- a/QuestAppsDownloader.DTO/QuestAppsDownloader.DTO.csproj
+++ b/QuestAppsDownloader.DTO/QuestAppsDownloader.DTO.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/QuestAppsDownloader.Services/Implementations/Tools/FileManager.cs
+++ b/QuestAppsDownloader.Services/Implementations/Tools/FileManager.cs
@@ -45,13 +45,20 @@ public class FileManager : IFileManager
         {
             CreateDirectory(outputDirectory);
 
-            var archive = SevenZipArchive.Open(filePath, readerOptions: new SharpCompress.Readers.ReaderOptions { Password = password });
+            var archive = SevenZipArchive.Open(filePath, readerOptions: new ReaderOptions { Password = password });
 
             var reader = archive.ExtractAllEntries();
             while (reader.MoveToNextEntry())
             {
-                if (!reader.Entry.IsDirectory)
-                    reader.WriteEntryToDirectory(outputDirectory, new ExtractionOptions { ExtractFullPath = true, Overwrite = true });
+                try
+                {
+                    if (!reader.Entry.IsDirectory)
+                        reader.WriteEntryToDirectory(outputDirectory, new ExtractionOptions { ExtractFullPath = true, Overwrite = true });
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"An error occured when extracting some file : {ex.Message}");
+                }
             }
 
             reader.Dispose();
@@ -61,6 +68,7 @@ public class FileManager : IFileManager
 
     public string GetFilePath(string directoryPath, string fileName)
     {
+        CreateDirectory(directoryPath);
         return Directory.GetFiles(directoryPath, fileName, SearchOption.AllDirectories).FirstOrDefault();
     }
 

--- a/QuestAppsDownloader.Services/QuestAppsDownloader.Services.csproj
+++ b/QuestAppsDownloader.Services/QuestAppsDownloader.Services.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="7.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RcloneWrapper" Version="1.60.0.9" />
-    <PackageReference Include="SharpCompress" Version="0.34.1" />
+    <PackageReference Include="RcloneWrapper" Version="1.60.0.12" />
+    <PackageReference Include="SharpCompress" Version="0.40.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuestAppsDownloader/QuestAppsDownloader.csproj
+++ b/QuestAppsDownloader/QuestAppsDownloader.csproj
@@ -2,19 +2,19 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows7.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="7.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuestAppsDownloader/appsettings.json
+++ b/QuestAppsDownloader/appsettings.json
@@ -4,7 +4,7 @@
     "AlternativeUrl": "https://github.com/rclone/rclone/releases/download/v1.64.2/rclone-v1.64.2-windows-amd64.zip"
   },
   "VRPPublicConfiguration": {
-    "Url": "https://wiki.vrpirates.club/downloads/vrp-public.json"
+    "Url": "https://vrpirates.wiki/downloads/vrp-public.json"
   },
   "MetadataConfiguration": {
     "MetadataCloudPath": ":http:/meta.7z"

--- a/Tests/QuestAppsDownloader.Services.Tests/QuestAppsDownloader.Services.Tests.csproj
+++ b/Tests/QuestAppsDownloader.Services.Tests/QuestAppsDownloader.Services.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 
     <IsPackable>false</IsPackable>
@@ -9,16 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Fix archive extraction error when extracting file with weird character. (error logging and skipping the file)
Bump .Net to version 8.
Bump nugets version to latest.
Update vrp-public.json url.